### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Rodrigo Munoz
 maintainer=Rodrigo Munoz
 sentence=ADXL377
 paragraph=ADXL377
+category=Sensors
 url=https://github.com/rorromr/ADXL377
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library ADXL377 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format